### PR TITLE
Use slugify instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,11 @@ jobs:
       MIX_ENV: test
     strategy:
       matrix:
-        elixir: ['1.10', '1.11', '1.12']
-        otp: ['23', '24']
+        elixir: ['1.13', '1.14']
+        otp: ['24', '25']
+        include:
+          - elixir: '1.12'
+            otp: '24'
     continue-on-error: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/ecto_autoslug_field/)
 [![License](https://img.shields.io/hexpm/l/ecto_autoslug_field.svg)](https://github.com/sobolevn/ecto_autoslug_field/blob/master/LICENSE)
 
-`ecto_autoslug_field` is a reusable [`Ecto`](https://github.com/elixir-ecto/ecto) library which can automatically create slugs from other fields. We use [`slugger`](https://github.com/h4cc/slugger) as a default slug-engine.
+`ecto_autoslug_field` is a reusable [`Ecto`](https://github.com/elixir-ecto/ecto) library which can automatically create slugs from other fields. We use [`slugify`](https://github.com/jayjun/slugify) as a default slug-engine.
 
 We only depend on the `ecto` package (we do not deal with `ecto_sql` at all).
 We support `ecto >= 3.7 and ecto < 4`!

--- a/lib/ecto_autoslug_field/slug.ex
+++ b/lib/ecto_autoslug_field/slug.ex
@@ -62,7 +62,7 @@ defmodule EctoAutoslugField.SlugBase do
   This function is a place to modify the result slug.
   For convenience you can call `super(sources, changeset)`
   which will return the slug binary.
-  `super(sources)` uses [`Slugger`](https://github.com/h4cc/slugger),
+  `super(sources)` uses [`slugify`](https://github.com/jayjun/slugify),
   but you can completely change slug-engine to your own.
 
   Note: this function will only be called if `sources` is not empty.

--- a/lib/ecto_autoslug_field/slug_generator.ex
+++ b/lib/ecto_autoslug_field/slug_generator.ex
@@ -1,6 +1,6 @@
 defmodule EctoAutoslugField.SlugGenerator do
   @moduledoc """
-  This module works with slugs itself. It is just a wrapper around 'Slugger'.
+  This module works with slugs itself. It is just a wrapper around 'Slugify'.
 
   It is suited for inner use.
   """
@@ -46,13 +46,13 @@ defmodule EctoAutoslugField.SlugGenerator do
 
   defp do_build_slug(source) when is_binary(source) do
     source
-    |> Slugger.slugify_downcase()
+    |> Slug.slugify()
   end
 
   defp do_build_slug(sources) do
     sources
     |> Enum.join("-")
-    |> Slugger.slugify_downcase()
+    |> Slug.slugify()
   end
 
   defp do_generate_slug(changeset, sources, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule EctoAutoslugField.Mixfile do
       {:ecto, ">= 3.7.0"},
 
       # Slugs:
-      {:slugger, ">= 0.3.0"},
+      {:slugify, "~> 1.3"},
 
       # Testing:
       {:excoveralls, "~> 0.14", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -20,7 +20,7 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "slugger": {:hex, :slugger, "0.3.0", "efc667ab99eee19a48913ccf3d038b1fb9f165fa4fbf093be898b8099e61b6ed", [:mix], [], "hexpm", "20d0ded0e712605d1eae6c5b4889581c3460d92623a930ddda91e0e609b5afba"},
+  "slugify": {:hex, :slugify, "1.3.1", "0d3b8b7e5c1eeaa960e44dce94382bee34a39b3ea239293e457a9c5b47cc6fd3", [:mix], [], "hexpm", "cb090bbeb056b312da3125e681d98933a360a70d327820e4b7f91645c4d8be76"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},


### PR DESCRIPTION
The reason you need to change Slugger to Slugify is because it supports Unicode correctly.

```Elixir
iex(1)> Slug.slugify "BoOoOo~~~👻👻"
"booooo"

iex(2)> Slugger.slugify "BoOoOo~~~👻👻"
<<66, 111, 79, 111, 79, 111, 45, 159, 145, 187, 45, 159, 145, 187>>
```