### PR TITLE
Allow setting first-time-slug

### DIFF
--- a/lib/ecto_autoslug_field/slug_generator.ex
+++ b/lib/ecto_autoslug_field/slug_generator.ex
@@ -60,7 +60,7 @@ defmodule EctoAutoslugField.SlugGenerator do
     slug_builder = Keyword.get(opts, :slug_builder)
     always_change = Keyword.get(opts, :always_change, false)
 
-    slug_field = Map.get(changeset.data, slug_key)
+    slug_field = Ecto.Changeset.get_field(changeset, slug_key)
 
     if always_change == true or slug_field == nil do
       # We only generate slug on two occasions:


### PR DESCRIPTION
Hi,

Thanks for this package, it has been helpful for us. For our use case we found one issue, this PR is meant as a starting point for discussion.

In our application we allow users to set the slug. This works fine for content that already exists (is persisted to DB), but when creating new content the slug generator will override the given slug resulting in duplicates.

If you want to, I can also add tests to demonstrate what it fixes?

Best,
Tonći ( @tuxified )